### PR TITLE
Fix schedule start dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "chickenbot",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "chickenbot",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/formbody": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "chickenbot",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Group task scheduling and reminders using Google Sheets and Twilio",
 	"main": "dist/server.js",
 	"dependencies": {

--- a/src/controllers/calendar.ts
+++ b/src/controllers/calendar.ts
@@ -259,12 +259,14 @@ class Calendar {
 		let startDate = moment.default();
 		let assignmentDate: moment.Moment;
 		for (let assignment of this.assignments) {
-			assignmentDate = moment.default(assignment.date, 'M/D');
-			if (
-				assignmentDate.format('YYYY-MM-DD') >
-				startDate.format('YYYY-MM-DD')
-			) {
-				startDate = assignmentDate;
+			if (assignment.sheet == 'Upcoming') {
+				assignmentDate = moment.default(assignment.date, 'M/D');
+				if (
+					assignmentDate.format('YYYY-MM-DD') >
+					startDate.format('YYYY-MM-DD')
+				) {
+					startDate = assignmentDate;
+				}
 			}
 		}
 		console.log(startDate.format('YYYY-MM-DD'));


### PR DESCRIPTION
When considering the start/end dates for a given week, only look at assignments that are upcoming—previously the archived assignments were also being considered.